### PR TITLE
feat: bump alpine base images tags to 3.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
           - linux/ppc64le
           - linux/s390x
         base_tag:
-          - 18-alpine3.18
-          - 20-alpine3.18
+          - 18-alpine3.19
+          - 20-alpine3.19
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1


### PR DESCRIPTION
#  Bump alpine base images tag to 3.19 #

## 🗣 Description ##

Bump the alpine base images tags to use newly released 3.19

## 💭 Motivation and context ##

To continue to track the issue on docker alpine images, it is good to check against new releases version.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*

## ✅ Pre-merge checklist ##

## ✅ Post-merge checklist ##